### PR TITLE
token-swap: Add fixed token B price

### DIFF
--- a/token-swap/program/src/curve/constant_price.rs
+++ b/token-swap/program/src/curve/constant_price.rs
@@ -273,7 +273,12 @@ mod tests {
         assert_eq!(curve, unpacked);
     }
 
-    fn check_pool_token_conversion(token_b_price: u128, swap_token_a_amount: u128, swap_token_b_amount: u128, token_b_amount: u128) {
+    fn check_pool_token_conversion(
+        token_b_price: u128,
+        swap_token_a_amount: u128,
+        swap_token_b_amount: u128,
+        token_b_amount: u128,
+    ) {
         let token_a_amount = token_b_amount * token_b_price;
         let curve = ConstantPriceCurve {
             token_b_price: token_b_price as u64,
@@ -309,18 +314,14 @@ mod tests {
             (1_000_251, 0, 1_288, 1),
             (1_000_000_000_000, 212, 10_000, 1),
         ];
-        for (
-            token_b_price,
-            swap_token_a_amount,
-            swap_token_b_amount,
-            token_b_amount
-        ) in tests.iter()
+        for (token_b_price, swap_token_a_amount, swap_token_b_amount, token_b_amount) in
+            tests.iter()
         {
             check_pool_token_conversion(
                 *token_b_price,
                 *swap_token_a_amount,
                 *swap_token_b_amount,
-                *token_b_amount
+                *token_b_amount,
             );
         }
     }

--- a/token-swap/program/src/curve/constant_price.rs
+++ b/token-swap/program/src/curve/constant_price.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     curve::calculator::{
-        map_zero_to_none, CurveCalculator, DynPack, SwapWithoutFeesResult, TradeDirection,
+        map_zero_to_none, CurveCalculator, DynPack, SwapWithoutFeesResult, TradeDirection, TradingTokenResult,
     },
     error::SwapError,
 };
@@ -53,6 +53,54 @@ impl CurveCalculator for ConstantPriceCurve {
             source_amount_swapped,
             destination_amount_swapped,
         })
+    }
+
+    /// Get the amount of trading tokens for the given amount of pool tokens,
+    /// provided the total trading tokens and supply of pool tokens.
+    /// For the constant price curve, the total value of the pool is weighted
+    /// by the price of token B.
+    fn pool_tokens_to_trading_tokens(
+        &self,
+        pool_tokens: u128,
+        pool_token_supply: u128,
+        swap_token_a_amount: u128,
+        swap_token_b_amount: u128,
+    ) -> Option<TradingTokenResult> {
+        // Split the pool tokens in half, send half as token A, half as token B
+        let token_a_pool_tokens = pool_tokens.checked_div(2)?;
+        let token_b_pool_tokens = pool_tokens.checked_sub(token_a_pool_tokens)?;
+
+        let token_b_price = self.token_b_price as u128;
+        let total_value = swap_token_b_amount.checked_mul(token_b_price)?.checked_add(swap_token_a_amount)?;
+
+        let token_a_amount = token_a_pool_tokens
+            .checked_mul(total_value)?
+            .checked_div(pool_token_supply)?;
+        let token_b_amount = token_b_pool_tokens
+            .checked_mul(total_value)?
+            .checked_div(token_b_price)?
+            .checked_div(pool_token_supply)?;
+        Some(TradingTokenResult {
+            token_a_amount,
+            token_b_amount,
+        })
+    }
+
+    /// Get the amount of pool tokens for the given amount of token A and B
+    /// For the constant price curve, the total value of the pool is weighted
+    /// by the price of token B.
+    fn trading_tokens_to_pool_tokens(
+        &self,
+        token_a_amount: u128,
+        swap_token_a_amount: u128,
+        token_b_amount: u128,
+        swap_token_b_amount: u128,
+        pool_supply: u128,
+    ) -> Option<u128> {
+        let token_b_price = self.token_b_price as u128;
+        let given_value = token_b_amount.checked_mul(token_b_price)?.checked_add(token_a_amount)?;
+        let total_value = swap_token_b_amount.checked_mul(token_b_price)?.checked_add(swap_token_a_amount)?;
+        pool_supply.checked_mul(given_value)?.checked_div(total_value)
     }
 
     fn validate(&self) -> Result<(), SwapError> {
@@ -214,5 +262,31 @@ mod tests {
         packed.extend_from_slice(&token_b_price.to_le_bytes());
         let unpacked = ConstantPriceCurve::unpack(&packed).unwrap();
         assert_eq!(curve, unpacked);
+    }
+
+    #[test]
+    fn pool_token_conversion() {
+        let token_b_price = 10_000;
+        let swap_token_a_amount = 1_000_000;
+        let swap_token_b_amount = 1;
+        let curve = ConstantPriceCurve { token_b_price: token_b_price as u64 };
+        let token_b_amount = 10;
+        let token_a_amount = token_b_amount * token_b_price;
+        let pool_supply = curve.new_pool_supply();
+        let pool_tokens = curve.trading_tokens_to_pool_tokens(
+            token_a_amount,
+            swap_token_a_amount,
+            token_b_amount,
+            swap_token_b_amount,
+            pool_supply,
+        ).unwrap();
+        let results = curve.pool_tokens_to_trading_tokens(
+            pool_tokens,
+            pool_supply,
+            swap_token_a_amount,
+            swap_token_b_amount,
+        ).unwrap();
+        assert_eq!(results.token_a_amount, token_a_amount - 1); // as long as we don't create more, we're good
+        assert_eq!(results.token_b_amount, token_b_amount);
     }
 }

--- a/token-swap/program/src/curve/constant_price.rs
+++ b/token-swap/program/src/curve/constant_price.rs
@@ -6,11 +6,11 @@ use crate::{
     },
     error::SwapError,
 };
+use arrayref::{array_mut_ref, array_ref};
 use solana_program::{
     program_error::ProgramError,
     program_pack::{IsInitialized, Pack, Sealed},
 };
-use arrayref::{array_mut_ref, array_ref};
 
 /// ConstantPriceCurve struct implementing CurveCalculator
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -199,7 +199,6 @@ mod tests {
         assert_eq!(result.source_amount_swapped, token_b_price);
         assert_eq!(result.destination_amount_swapped, 1u128);
     }
-
 
     #[test]
     fn pack_flat_curve() {

--- a/token-swap/program/src/curve/constant_price.rs
+++ b/token-swap/program/src/curve/constant_price.rs
@@ -2,7 +2,8 @@
 
 use crate::{
     curve::calculator::{
-        map_zero_to_none, CurveCalculator, DynPack, SwapWithoutFeesResult, TradeDirection, TradingTokenResult,
+        map_zero_to_none, CurveCalculator, DynPack, SwapWithoutFeesResult, TradeDirection,
+        TradingTokenResult,
     },
     error::SwapError,
 };
@@ -71,7 +72,9 @@ impl CurveCalculator for ConstantPriceCurve {
         let token_b_pool_tokens = pool_tokens.checked_sub(token_a_pool_tokens)?;
 
         let token_b_price = self.token_b_price as u128;
-        let total_value = swap_token_b_amount.checked_mul(token_b_price)?.checked_add(swap_token_a_amount)?;
+        let total_value = swap_token_b_amount
+            .checked_mul(token_b_price)?
+            .checked_add(swap_token_a_amount)?;
 
         let token_a_amount = token_a_pool_tokens
             .checked_mul(total_value)?
@@ -98,9 +101,15 @@ impl CurveCalculator for ConstantPriceCurve {
         pool_supply: u128,
     ) -> Option<u128> {
         let token_b_price = self.token_b_price as u128;
-        let given_value = token_b_amount.checked_mul(token_b_price)?.checked_add(token_a_amount)?;
-        let total_value = swap_token_b_amount.checked_mul(token_b_price)?.checked_add(swap_token_a_amount)?;
-        pool_supply.checked_mul(given_value)?.checked_div(total_value)
+        let given_value = token_b_amount
+            .checked_mul(token_b_price)?
+            .checked_add(token_a_amount)?;
+        let total_value = swap_token_b_amount
+            .checked_mul(token_b_price)?
+            .checked_add(swap_token_a_amount)?;
+        pool_supply
+            .checked_mul(given_value)?
+            .checked_div(total_value)
     }
 
     fn validate(&self) -> Result<(), SwapError> {
@@ -264,29 +273,55 @@ mod tests {
         assert_eq!(curve, unpacked);
     }
 
+    fn check_pool_token_conversion(token_b_price: u128, swap_token_a_amount: u128, swap_token_b_amount: u128, token_b_amount: u128) {
+        let token_a_amount = token_b_amount * token_b_price;
+        let curve = ConstantPriceCurve {
+            token_b_price: token_b_price as u64,
+        };
+        let pool_supply = curve.new_pool_supply();
+        let pool_tokens = curve
+            .trading_tokens_to_pool_tokens(
+                token_a_amount,
+                swap_token_a_amount,
+                token_b_amount,
+                swap_token_b_amount,
+                pool_supply,
+            )
+            .unwrap();
+        let results = curve
+            .pool_tokens_to_trading_tokens(
+                pool_tokens,
+                pool_supply,
+                swap_token_a_amount,
+                swap_token_b_amount,
+            )
+            .unwrap();
+        assert!(results.token_a_amount <= token_a_amount); // as long as we don't create more value, we're good
+        assert_eq!(results.token_b_amount, token_b_amount);
+    }
+
     #[test]
     fn pool_token_conversion() {
-        let token_b_price = 10_000;
-        let swap_token_a_amount = 1_000_000;
-        let swap_token_b_amount = 1;
-        let curve = ConstantPriceCurve { token_b_price: token_b_price as u64 };
-        let token_b_amount = 10;
-        let token_a_amount = token_b_amount * token_b_price;
-        let pool_supply = curve.new_pool_supply();
-        let pool_tokens = curve.trading_tokens_to_pool_tokens(
-            token_a_amount,
-            swap_token_a_amount,
-            token_b_amount,
-            swap_token_b_amount,
-            pool_supply,
-        ).unwrap();
-        let results = curve.pool_tokens_to_trading_tokens(
-            pool_tokens,
-            pool_supply,
+        let tests: &[(u128, u128, u128, u128)] = &[
+            (10_000, 1_000_000, 1, 10),
+            (10, 1_000, 100, 1),
+            (1_251, 30, 1_288, 1_225),
+            (1_000_251, 0, 1_288, 1),
+            (1_000_000_000_000, 212, 10_000, 1),
+        ];
+        for (
+            token_b_price,
             swap_token_a_amount,
             swap_token_b_amount,
-        ).unwrap();
-        assert_eq!(results.token_a_amount, token_a_amount - 1); // as long as we don't create more, we're good
-        assert_eq!(results.token_b_amount, token_b_amount);
+            token_b_amount
+        ) in tests.iter()
+        {
+            check_pool_token_conversion(
+                *token_b_price,
+                *swap_token_a_amount,
+                *swap_token_b_amount,
+                *token_b_amount
+            );
+        }
     }
 }

--- a/token-swap/program/src/curve/constant_price.rs
+++ b/token-swap/program/src/curve/constant_price.rs
@@ -1,17 +1,23 @@
 //! Simple constant price swap curve, set at init
 
 use crate::{
-    curve::calculator::{CurveCalculator, DynPack, SwapWithoutFeesResult, TradeDirection},
+    curve::calculator::{
+        map_zero_to_none, CurveCalculator, DynPack, SwapWithoutFeesResult, TradeDirection,
+    },
     error::SwapError,
 };
 use solana_program::{
     program_error::ProgramError,
     program_pack::{IsInitialized, Pack, Sealed},
 };
+use arrayref::{array_mut_ref, array_ref};
 
 /// ConstantPriceCurve struct implementing CurveCalculator
 #[derive(Clone, Debug, Default, PartialEq)]
-pub struct ConstantPriceCurve;
+pub struct ConstantPriceCurve {
+    /// Amount of token A required to get 1 token B
+    pub token_b_price: u64,
+}
 
 impl CurveCalculator for ConstantPriceCurve {
     /// Constant price curve always returns 1:1
@@ -20,16 +26,41 @@ impl CurveCalculator for ConstantPriceCurve {
         source_amount: u128,
         _swap_source_amount: u128,
         _swap_destination_amount: u128,
-        _trade_direction: TradeDirection,
+        trade_direction: TradeDirection,
     ) -> Option<SwapWithoutFeesResult> {
+        let token_b_price = self.token_b_price as u128;
+
+        let (source_amount_swapped, destination_amount_swapped) = match trade_direction {
+            TradeDirection::BtoA => (source_amount, source_amount.checked_mul(token_b_price)?),
+            TradeDirection::AtoB => {
+                let destination_amount_swapped = source_amount.checked_div(token_b_price)?;
+                let mut source_amount_swapped = source_amount;
+
+                // if there is a remainder from buying token B, floor
+                // token_a_amount provided to avoid taking too many tokens, but
+                // don't recalculate the fees
+                let remainder = source_amount_swapped.checked_rem(token_b_price)?;
+                if remainder > 0 {
+                    source_amount_swapped = source_amount.checked_sub(remainder)?;
+                }
+                (source_amount_swapped, destination_amount_swapped)
+            }
+        };
+        let source_amount_swapped = map_zero_to_none(source_amount_swapped)?;
+        let destination_amount_swapped = map_zero_to_none(destination_amount_swapped)?;
+
         Some(SwapWithoutFeesResult {
-            source_amount_swapped: source_amount,
-            destination_amount_swapped: source_amount,
+            source_amount_swapped,
+            destination_amount_swapped,
         })
     }
 
     fn validate(&self) -> Result<(), SwapError> {
-        Ok(())
+        if self.token_b_price == 0 {
+            Err(SwapError::InvalidCurve)
+        } else {
+            Ok(())
+        }
     }
 
     fn validate_supply(&self, token_a_amount: u64, _token_b_amount: u64) -> Result<(), SwapError> {
@@ -48,18 +79,24 @@ impl IsInitialized for ConstantPriceCurve {
 }
 impl Sealed for ConstantPriceCurve {}
 impl Pack for ConstantPriceCurve {
-    const LEN: usize = 0;
+    const LEN: usize = 8;
     fn pack_into_slice(&self, output: &mut [u8]) {
         (self as &dyn DynPack).pack_into_slice(output);
     }
 
-    fn unpack_from_slice(_input: &[u8]) -> Result<ConstantPriceCurve, ProgramError> {
-        Ok(Self {})
+    fn unpack_from_slice(input: &[u8]) -> Result<ConstantPriceCurve, ProgramError> {
+        let token_b_price = array_ref![input, 0, 8];
+        Ok(Self {
+            token_b_price: u64::from_le_bytes(*token_b_price),
+        })
     }
 }
 
 impl DynPack for ConstantPriceCurve {
-    fn pack_into_slice(&self, _output: &mut [u8]) {}
+    fn pack_into_slice(&self, output: &mut [u8]) {
+        let token_b_price = array_mut_ref![output, 0, 8];
+        *token_b_price = self.token_b_price.to_le_bytes();
+    }
 }
 
 #[cfg(test)]
@@ -71,7 +108,8 @@ mod tests {
         let swap_source_amount: u128 = 0;
         let swap_destination_amount: u128 = 0;
         let source_amount: u128 = 100;
-        let curve = ConstantPriceCurve {};
+        let token_b_price = 1;
+        let curve = ConstantPriceCurve { token_b_price };
 
         let expected_result = SwapWithoutFeesResult {
             source_amount_swapped: source_amount,
@@ -100,15 +138,81 @@ mod tests {
     }
 
     #[test]
+    fn swap_calculation_large_price() {
+        let token_b_price = 1123513u128;
+        let curve = ConstantPriceCurve {
+            token_b_price: token_b_price as u64,
+        };
+        let token_b_amount = 500u128;
+        let token_a_amount = token_b_amount * token_b_price;
+        let bad_result = curve.swap_without_fees(
+            token_b_price - 1u128,
+            token_a_amount,
+            token_b_amount,
+            TradeDirection::AtoB,
+        );
+        assert!(bad_result.is_none());
+        let bad_result =
+            curve.swap_without_fees(1u128, token_a_amount, token_b_amount, TradeDirection::AtoB);
+        assert!(bad_result.is_none());
+        let result = curve
+            .swap_without_fees(
+                token_b_price,
+                token_a_amount,
+                token_b_amount,
+                TradeDirection::AtoB,
+            )
+            .unwrap();
+        assert_eq!(result.source_amount_swapped, token_b_price);
+        assert_eq!(result.destination_amount_swapped, 1u128);
+    }
+
+    #[test]
+    fn swap_calculation_max_min() {
+        let token_b_price = u64::MAX as u128;
+        let curve = ConstantPriceCurve {
+            token_b_price: token_b_price as u64,
+        };
+        let token_b_amount = 1u128;
+        let token_a_amount = token_b_price;
+        let bad_result = curve.swap_without_fees(
+            token_b_price - 1u128,
+            token_a_amount,
+            token_b_amount,
+            TradeDirection::AtoB,
+        );
+        assert!(bad_result.is_none());
+        let bad_result =
+            curve.swap_without_fees(1u128, token_a_amount, token_b_amount, TradeDirection::AtoB);
+        assert!(bad_result.is_none());
+        let bad_result =
+            curve.swap_without_fees(0u128, token_a_amount, token_b_amount, TradeDirection::AtoB);
+        assert!(bad_result.is_none());
+        let result = curve
+            .swap_without_fees(
+                token_b_price,
+                token_a_amount,
+                token_b_amount,
+                TradeDirection::AtoB,
+            )
+            .unwrap();
+        assert_eq!(result.source_amount_swapped, token_b_price);
+        assert_eq!(result.destination_amount_swapped, 1u128);
+    }
+
+
+    #[test]
     fn pack_flat_curve() {
-        let curve = ConstantPriceCurve {};
+        let token_b_price = u64::MAX;
+        let curve = ConstantPriceCurve { token_b_price };
 
         let mut packed = [0u8; ConstantPriceCurve::LEN];
         Pack::pack_into_slice(&curve, &mut packed[..]);
         let unpacked = ConstantPriceCurve::unpack(&packed).unwrap();
         assert_eq!(curve, unpacked);
 
-        let packed = vec![];
+        let mut packed = vec![];
+        packed.extend_from_slice(&token_b_price.to_le_bytes());
         let unpacked = ConstantPriceCurve::unpack(&packed).unwrap();
         assert_eq!(curve, unpacked);
     }

--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -1997,8 +1997,9 @@ mod tests {
         // create valid swap
         accounts.initialize_swap().unwrap();
 
-        // create valid flat swap
+        // create invalid flat swap
         {
+            let token_b_price = 0;
             let fees = Fees {
                 trade_fee_numerator,
                 trade_fee_denominator,
@@ -2011,7 +2012,32 @@ mod tests {
             };
             let swap_curve = SwapCurve {
                 curve_type: CurveType::ConstantPrice,
-                calculator: Box::new(ConstantPriceCurve {}),
+                calculator: Box::new(ConstantPriceCurve { token_b_price }),
+            };
+            let mut accounts =
+                SwapAccountInfo::new(&user_key, fees, swap_curve, token_a_amount, token_b_amount);
+            assert_eq!(
+                Err(SwapError::InvalidCurve.into()),
+                accounts.initialize_swap()
+            );
+        }
+
+        // create valid flat swap
+        {
+            let token_b_price = 10;
+            let fees = Fees {
+                trade_fee_numerator,
+                trade_fee_denominator,
+                owner_trade_fee_numerator,
+                owner_trade_fee_denominator,
+                owner_withdraw_fee_numerator,
+                owner_withdraw_fee_denominator,
+                host_fee_numerator,
+                host_fee_denominator,
+            };
+            let swap_curve = SwapCurve {
+                curve_type: CurveType::ConstantPrice,
+                calculator: Box::new(ConstantPriceCurve { token_b_price }),
             };
             let mut accounts =
                 SwapAccountInfo::new(&user_key, fees, swap_curve, token_a_amount, token_b_amount);
@@ -3876,10 +3902,11 @@ mod tests {
             token_a_amount,
             token_b_amount,
         );
+        let token_b_price = 1;
         check_valid_swap_curve(
             fees,
             CurveType::ConstantPrice,
-            Box::new(ConstantPriceCurve {}),
+            Box::new(ConstantPriceCurve { token_b_price }),
             token_a_amount,
             token_b_amount,
         );
@@ -3916,12 +3943,13 @@ mod tests {
             token_a_amount,
             token_b_amount,
         );
+        let token_b_price = 1_000;
         check_valid_swap_curve(
             fees,
             CurveType::ConstantPrice,
-            Box::new(ConstantPriceCurve {}),
+            Box::new(ConstantPriceCurve { token_b_price }),
             token_a_amount,
-            token_b_amount,
+            token_b_amount / token_b_price,
         );
     }
 


### PR DESCRIPTION
The tricky part of this comes from the conversion of pool tokens <-> trading tokens.  Since each pool token represents a part of the total value of the liquidity accounts, we need to know the total value of the pool, as perceived by the curve.  For the constant price curve, the total value is simple, thankfully: `token_a_amount * token_b_price + token_b_amount`.  There's also a test to make sure that the round trip conversion doesn't create any value from nothing.  This will get expanded in the fuzzing PR.