### PR TITLE
Add offset curve

### DIFF
--- a/token-swap/program/src/curve/base.rs
+++ b/token-swap/program/src/curve/base.rs
@@ -10,6 +10,7 @@ use crate::curve::{
     constant_price::ConstantPriceCurve,
     constant_product::ConstantProductCurve,
     fees::Fees,
+    offset::OffsetCurve,
     stable::StableCurve,
 };
 use arrayref::{array_mut_ref, array_ref, array_refs, mut_array_refs};
@@ -24,8 +25,10 @@ pub enum CurveType {
     ConstantProduct,
     /// Flat line, always providing 1:1 from one token to another
     ConstantPrice,
-    /// Stable, Like uniswap, but with wide zone of 1:1 instead of one point
+    /// Stable, like uniswap, but with wide zone of 1:1 instead of one point
     Stable,
+    /// Offset curve, like Uniswap, but the token B side has a faked offset
+    Offset,
 }
 
 /// Encodes all results of swapping from a source token to a destination token
@@ -191,6 +194,7 @@ impl Pack for SwapCurve {
                     Box::new(ConstantPriceCurve::unpack_from_slice(calculator)?)
                 }
                 CurveType::Stable => Box::new(StableCurve::unpack_from_slice(calculator)?),
+                CurveType::Offset => Box::new(OffsetCurve::unpack_from_slice(calculator)?),
             },
         })
     }
@@ -220,6 +224,7 @@ impl TryFrom<u8> for CurveType {
             0 => Ok(CurveType::ConstantProduct),
             1 => Ok(CurveType::ConstantPrice),
             2 => Ok(CurveType::Stable),
+            3 => Ok(CurveType::Offset),
             _ => Err(ProgramError::InvalidAccountData),
         }
     }

--- a/token-swap/program/src/curve/calculator.rs
+++ b/token-swap/program/src/curve/calculator.rs
@@ -11,7 +11,7 @@ pub const INITIAL_SWAP_POOL_AMOUNT: u128 = 1_000_000_000;
 
 /// Hardcode the number of token types in a pool, used to calculate the
 /// equivalent pool tokens for the owner trading fee.
-const TOKENS_IN_POOL: u128 = 2;
+pub const TOKENS_IN_POOL: u128 = 2;
 
 /// Helper function for mapping to SwapError::CalculationFailure
 pub fn map_zero_to_none(x: u128) -> Option<u128> {

--- a/token-swap/program/src/curve/mod.rs
+++ b/token-swap/program/src/curve/mod.rs
@@ -6,4 +6,5 @@ pub mod constant_price;
 pub mod constant_product;
 pub mod fees;
 pub mod math;
+pub mod offset;
 pub mod stable;

--- a/token-swap/program/src/curve/offset.rs
+++ b/token-swap/program/src/curve/offset.rs
@@ -3,7 +3,7 @@
 use crate::{
     curve::{
         calculator::{
-            CurveCalculator, DynPack, SwapWithoutFeesResult, TradeDirection, TradingTokenResult,
+            TOKENS_IN_POOL, CurveCalculator, DynPack, SwapWithoutFeesResult, TradeDirection, TradingTokenResult,
         },
         constant_product::swap,
     },
@@ -77,12 +77,16 @@ impl CurveCalculator for OffsetCurve {
         pool_supply: u128,
     ) -> Option<u128> {
         let token_b_offset = self.token_b_offset as u128;
+        let new_swap_token_a_amount = swap_token_a_amount.checked_add(token_a_amount)?;
         let token_a_as_pool_tokens = pool_supply
             .checked_mul(token_a_amount)?
-            .checked_div(swap_token_a_amount)?;
+            .checked_div(new_swap_token_a_amount)?
+            .checked_div(TOKENS_IN_POOL)?;
+        let new_swap_token_b_amount = swap_token_b_amount.checked_add(token_b_amount)?;
         let token_b_as_pool_tokens = pool_supply
             .checked_mul(token_b_amount)?
-            .checked_div(swap_token_b_amount.checked_add(token_b_offset)?)?;
+            .checked_div(new_swap_token_b_amount.checked_add(token_b_offset)?)?
+            .checked_div(TOKENS_IN_POOL)?;
         token_a_as_pool_tokens.checked_add(token_b_as_pool_tokens)
     }
 

--- a/token-swap/program/src/curve/offset.rs
+++ b/token-swap/program/src/curve/offset.rs
@@ -1,0 +1,322 @@
+//! The Uniswap invariant calculator with an extra offset
+
+use crate::{
+    curve::{
+        calculator::{
+            CurveCalculator, DynPack, SwapWithoutFeesResult, TradeDirection, TradingTokenResult,
+        },
+        constant_product::swap,
+    },
+    error::SwapError,
+};
+use arrayref::{array_mut_ref, array_ref};
+use solana_program::{
+    program_error::ProgramError,
+    program_pack::{IsInitialized, Pack, Sealed},
+};
+
+/// Offset curve, uses ConstantProduct under the hood, but adds an offset to
+/// one side on swap calculations
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct OffsetCurve {
+    /// Amount to offset the token B liquidity account
+    pub token_b_offset: u64,
+}
+
+impl CurveCalculator for OffsetCurve {
+    /// Constant product swap ensures token a * (token b + offset) = constant
+    fn swap_without_fees(
+        &self,
+        source_amount: u128,
+        swap_source_amount: u128,
+        swap_destination_amount: u128,
+        trade_direction: TradeDirection,
+    ) -> Option<SwapWithoutFeesResult> {
+        let token_b_offset = self.token_b_offset as u128;
+        let swap_source_amount = match trade_direction {
+            TradeDirection::AtoB => swap_source_amount,
+            TradeDirection::BtoA => swap_source_amount.checked_add(token_b_offset)?,
+        };
+        let swap_destination_amount = match trade_direction {
+            TradeDirection::AtoB => swap_destination_amount.checked_add(token_b_offset)?,
+            TradeDirection::BtoA => swap_destination_amount,
+        };
+        swap(source_amount, swap_source_amount, swap_destination_amount)
+    }
+
+    /// The conversion for the offset curve needs to take into account the
+    /// offset
+    fn pool_tokens_to_trading_tokens(
+        &self,
+        pool_tokens: u128,
+        pool_token_supply: u128,
+        swap_token_a_amount: u128,
+        swap_token_b_amount: u128,
+    ) -> Option<TradingTokenResult> {
+        let token_b_offset = self.token_b_offset as u128;
+        let token_a_amount = pool_tokens
+            .checked_mul(swap_token_a_amount)?
+            .checked_div(pool_token_supply)?;
+        let token_b_amount = pool_tokens
+            .checked_mul(swap_token_b_amount.checked_add(token_b_offset)?)?
+            .checked_div(pool_token_supply)?;
+        Some(TradingTokenResult {
+            token_a_amount,
+            token_b_amount,
+        })
+    }
+
+    /// Get the amount of pool tokens for the given amount of token A and B,
+    /// taking into account the offset
+    fn trading_tokens_to_pool_tokens(
+        &self,
+        token_a_amount: u128,
+        swap_token_a_amount: u128,
+        token_b_amount: u128,
+        swap_token_b_amount: u128,
+        pool_supply: u128,
+    ) -> Option<u128> {
+        let token_b_offset = self.token_b_offset as u128;
+        let token_a_as_pool_tokens = pool_supply
+            .checked_mul(token_a_amount)?
+            .checked_div(swap_token_a_amount)?;
+        let token_b_as_pool_tokens = pool_supply
+            .checked_mul(token_b_amount)?
+            .checked_div(swap_token_b_amount.checked_add(token_b_offset)?)?;
+        token_a_as_pool_tokens.checked_add(token_b_as_pool_tokens)
+    }
+
+    fn validate(&self) -> Result<(), SwapError> {
+        if self.token_b_offset == 0 {
+            Err(SwapError::InvalidCurve)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn validate_supply(&self, token_a_amount: u64, _token_b_amount: u64) -> Result<(), SwapError> {
+        if token_a_amount == 0 {
+            return Err(SwapError::EmptySupply);
+        }
+        Ok(())
+    }
+}
+
+/// IsInitialized is required to use `Pack::pack` and `Pack::unpack`
+impl IsInitialized for OffsetCurve {
+    fn is_initialized(&self) -> bool {
+        true
+    }
+}
+impl Sealed for OffsetCurve {}
+impl Pack for OffsetCurve {
+    const LEN: usize = 8;
+    fn pack_into_slice(&self, output: &mut [u8]) {
+        (self as &dyn DynPack).pack_into_slice(output);
+    }
+
+    fn unpack_from_slice(input: &[u8]) -> Result<OffsetCurve, ProgramError> {
+        let token_b_offset = array_ref![input, 0, 8];
+        Ok(Self {
+            token_b_offset: u64::from_le_bytes(*token_b_offset),
+        })
+    }
+}
+
+impl DynPack for OffsetCurve {
+    fn pack_into_slice(&self, output: &mut [u8]) {
+        let token_b_offset = array_mut_ref![output, 0, 8];
+        *token_b_offset = self.token_b_offset.to_le_bytes();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pack_curve() {
+        let token_b_offset = u64::MAX;
+        let curve = OffsetCurve { token_b_offset };
+
+        let mut packed = [0u8; OffsetCurve::LEN];
+        Pack::pack_into_slice(&curve, &mut packed[..]);
+        let unpacked = OffsetCurve::unpack(&packed).unwrap();
+        assert_eq!(curve, unpacked);
+
+        let mut packed = vec![];
+        packed.extend_from_slice(&token_b_offset.to_le_bytes());
+        let unpacked = OffsetCurve::unpack(&packed).unwrap();
+        assert_eq!(curve, unpacked);
+    }
+
+    #[test]
+    fn swap_no_offset() {
+        let swap_source_amount: u128 = 1_000;
+        let swap_destination_amount: u128 = 50_000;
+        let source_amount: u128 = 100;
+        let curve = OffsetCurve::default();
+        let result = curve
+            .swap_without_fees(
+                source_amount,
+                swap_source_amount,
+                swap_destination_amount,
+                TradeDirection::AtoB,
+            )
+            .unwrap();
+        assert_eq!(result.source_amount_swapped, source_amount);
+        assert_eq!(result.destination_amount_swapped, 4545);
+        let result = curve
+            .swap_without_fees(
+                source_amount,
+                swap_source_amount,
+                swap_destination_amount,
+                TradeDirection::BtoA,
+            )
+            .unwrap();
+        assert_eq!(result.source_amount_swapped, source_amount);
+        assert_eq!(result.destination_amount_swapped, 4545);
+    }
+
+    #[test]
+    fn swap_offset() {
+        let swap_source_amount: u128 = 1_000_000;
+        let swap_destination_amount: u128 = 0;
+        let source_amount: u128 = 100;
+        let token_b_offset = 1_000_000;
+        let curve = OffsetCurve { token_b_offset };
+        let result = curve
+            .swap_without_fees(
+                source_amount,
+                swap_source_amount,
+                swap_destination_amount,
+                TradeDirection::AtoB,
+            )
+            .unwrap();
+        assert_eq!(result.source_amount_swapped, source_amount);
+        assert_eq!(result.destination_amount_swapped, source_amount - 1);
+
+        let bad_result = curve.swap_without_fees(
+            source_amount,
+            swap_source_amount,
+            swap_destination_amount,
+            TradeDirection::BtoA,
+        );
+        assert!(bad_result.is_none());
+    }
+
+    #[test]
+    fn swap_a_to_b_max_offset() {
+        let swap_source_amount: u128 = 10_000_000;
+        let swap_destination_amount: u128 = 1_000;
+        let source_amount: u128 = 1_000;
+        let token_b_offset = u64::MAX;
+        let curve = OffsetCurve { token_b_offset };
+        let result = curve
+            .swap_without_fees(
+                source_amount,
+                swap_source_amount,
+                swap_destination_amount,
+                TradeDirection::AtoB,
+            )
+            .unwrap();
+        assert_eq!(result.source_amount_swapped, source_amount);
+        assert_eq!(result.destination_amount_swapped, 1_844_489_958_375_117);
+    }
+
+    #[test]
+    fn swap_b_to_a_max_offset() {
+        let swap_source_amount: u128 = 10_000_000;
+        let swap_destination_amount: u128 = 1_000;
+        let source_amount: u128 = u64::MAX.into();
+        let token_b_offset = u64::MAX;
+        let curve = OffsetCurve { token_b_offset };
+        let result = curve
+            .swap_without_fees(
+                source_amount,
+                swap_source_amount,
+                swap_destination_amount,
+                TradeDirection::BtoA,
+            )
+            .unwrap();
+        assert_eq!(result.source_amount_swapped, 18_373_104_376_818_475_561);
+        assert_eq!(result.destination_amount_swapped, 499);
+    }
+
+    fn check_pool_token_conversion(
+        token_b_offset: u128,
+        swap_token_a_amount: u128,
+        swap_token_b_amount: u128,
+        token_a_amount: u128,
+        token_b_amount: u128,
+    ) {
+        let curve = OffsetCurve {
+            token_b_offset: token_b_offset as u64,
+        };
+        let pool_supply = curve.new_pool_supply();
+        let pool_tokens = curve
+            .trading_tokens_to_pool_tokens(
+                token_a_amount,
+                swap_token_a_amount,
+                token_b_amount,
+                swap_token_b_amount,
+                pool_supply,
+            )
+            .unwrap();
+        let results = curve
+            .pool_tokens_to_trading_tokens(
+                pool_tokens,
+                pool_supply,
+                swap_token_a_amount,
+                swap_token_b_amount,
+            )
+            .unwrap();
+        let swap_results = curve
+            .swap_without_fees(
+                results.token_a_amount,
+                swap_token_a_amount,
+                swap_token_b_amount,
+                TradeDirection::AtoB,
+            )
+            .unwrap();
+        assert!(swap_results.source_amount_swapped <= results.token_a_amount);
+        assert!(swap_results.destination_amount_swapped <= results.token_b_amount);
+        let swap_results = curve
+            .swap_without_fees(
+                results.token_b_amount,
+                swap_token_b_amount,
+                swap_token_a_amount,
+                TradeDirection::BtoA,
+            )
+            .unwrap();
+        assert!(swap_results.source_amount_swapped <= results.token_b_amount);
+        assert!(swap_results.destination_amount_swapped <= results.token_a_amount);
+    }
+
+    #[test]
+    fn pool_token_conversion() {
+        let tests: &[(u128, u128, u128, u128, u128)] = &[
+            (10_000, 1_000_000, 1, 100_000, 10),
+            (10, 1_000, 100, 100_000, 1),
+            (1_251, 30, 1_288, 100_000, 1_225),
+            (1_000_251, 1_000, 1_288, 100_000, 1),
+            (1_000_000_000_000, 212, 10_000, 100_000, 1),
+        ];
+        for (
+            token_b_offset,
+            swap_token_a_amount,
+            swap_token_b_amount,
+            token_a_amount,
+            token_b_amount,
+        ) in tests.iter()
+        {
+            check_pool_token_conversion(
+                *token_b_offset,
+                *swap_token_a_amount,
+                *swap_token_b_amount,
+                *token_a_amount,
+                *token_b_amount,
+            );
+        }
+    }
+}

--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -816,7 +816,7 @@ mod tests {
         curve::calculator::{CurveCalculator, INITIAL_SWAP_POOL_AMOUNT},
         curve::{
             base::CurveType, constant_price::ConstantPriceCurve,
-            constant_product::ConstantProductCurve,
+            constant_product::ConstantProductCurve, offset::OffsetCurve,
         },
         instruction::{deposit, initialize, swap, withdraw},
     };
@@ -2012,6 +2012,53 @@ mod tests {
             let swap_curve = SwapCurve {
                 curve_type: CurveType::ConstantPrice,
                 calculator: Box::new(ConstantPriceCurve {}),
+            };
+            let mut accounts =
+                SwapAccountInfo::new(&user_key, fees, swap_curve, token_a_amount, token_b_amount);
+            accounts.initialize_swap().unwrap();
+        }
+
+        // create invalid offset swap
+        {
+            let token_b_offset = 0;
+            let fees = Fees {
+                trade_fee_numerator,
+                trade_fee_denominator,
+                owner_trade_fee_numerator,
+                owner_trade_fee_denominator,
+                owner_withdraw_fee_numerator,
+                owner_withdraw_fee_denominator,
+                host_fee_numerator,
+                host_fee_denominator,
+            };
+            let swap_curve = SwapCurve {
+                curve_type: CurveType::Offset,
+                calculator: Box::new(OffsetCurve { token_b_offset }),
+            };
+            let mut accounts =
+                SwapAccountInfo::new(&user_key, fees, swap_curve, token_a_amount, token_b_amount);
+            assert_eq!(
+                Err(SwapError::InvalidCurve.into()),
+                accounts.initialize_swap()
+            );
+        }
+
+        // create valid offset swap
+        {
+            let token_b_offset = 10;
+            let fees = Fees {
+                trade_fee_numerator,
+                trade_fee_denominator,
+                owner_trade_fee_numerator,
+                owner_trade_fee_denominator,
+                owner_withdraw_fee_numerator,
+                owner_withdraw_fee_denominator,
+                host_fee_numerator,
+                host_fee_denominator,
+            };
+            let swap_curve = SwapCurve {
+                curve_type: CurveType::Offset,
+                calculator: Box::new(OffsetCurve { token_b_offset }),
             };
             let mut accounts =
                 SwapAccountInfo::new(&user_key, fees, swap_curve, token_a_amount, token_b_amount);
@@ -3877,9 +3924,17 @@ mod tests {
             token_b_amount,
         );
         check_valid_swap_curve(
-            fees,
+            fees.clone(),
             CurveType::ConstantPrice,
             Box::new(ConstantPriceCurve {}),
+            token_a_amount,
+            token_b_amount,
+        );
+        let token_b_offset = 10_000_000_000;
+        check_valid_swap_curve(
+            fees,
+            CurveType::Offset,
+            Box::new(OffsetCurve { token_b_offset }),
             token_a_amount,
             token_b_amount,
         );
@@ -3917,9 +3972,17 @@ mod tests {
             token_b_amount,
         );
         check_valid_swap_curve(
-            fees,
+            fees.clone(),
             CurveType::ConstantPrice,
             Box::new(ConstantPriceCurve {}),
+            token_a_amount,
+            token_b_amount,
+        );
+        let token_b_offset = 1;
+        check_valid_swap_curve(
+            fees,
+            CurveType::Offset,
+            Box::new(OffsetCurve { token_b_offset }),
             token_a_amount,
             token_b_amount,
         );
@@ -4718,5 +4781,124 @@ mod tests {
                 ),
             );
         }
+    }
+
+    #[test]
+    fn test_overdraw_offset_curve() {
+        let trade_fee_numerator = 1;
+        let trade_fee_denominator = 10;
+        let owner_trade_fee_numerator = 1;
+        let owner_trade_fee_denominator = 30;
+        let owner_withdraw_fee_numerator = 1;
+        let owner_withdraw_fee_denominator = 30;
+        let host_fee_numerator = 10;
+        let host_fee_denominator = 100;
+
+        let token_a_amount = 1_000_000_000;
+        let token_b_amount = 0;
+        let fees = Fees {
+            trade_fee_numerator,
+            trade_fee_denominator,
+            owner_trade_fee_numerator,
+            owner_trade_fee_denominator,
+            owner_withdraw_fee_numerator,
+            owner_withdraw_fee_denominator,
+            host_fee_numerator,
+            host_fee_denominator,
+        };
+
+        let token_b_offset = 2_000_000;
+        let swap_curve = SwapCurve {
+            curve_type: CurveType::Offset,
+            calculator: Box::new(OffsetCurve { token_b_offset }),
+        };
+        let user_key = Pubkey::new_unique();
+        let swapper_key = Pubkey::new_unique();
+
+        let mut accounts =
+            SwapAccountInfo::new(&user_key, fees, swap_curve, token_a_amount, token_b_amount);
+
+        accounts.initialize_swap().unwrap();
+
+        let swap_token_a_key = accounts.token_a_key;
+        let swap_token_b_key = accounts.token_b_key;
+        let initial_a = 500_000;
+        let initial_b = 1_000;
+
+        let (
+            token_a_key,
+            mut token_a_account,
+            token_b_key,
+            mut token_b_account,
+            _pool_key,
+            _pool_account,
+        ) = accounts.setup_token_accounts(&user_key, &swapper_key, initial_a, initial_b, 0);
+
+        // swap a to b way, fails, there's no liquidity
+        let a_to_b_amount = initial_a;
+        let minimum_token_b_amount = 0;
+
+        assert_eq!(
+            Err(SwapError::ZeroTradingTokens.into()),
+            accounts.swap(
+                &swapper_key,
+                &token_a_key,
+                &mut token_a_account,
+                &swap_token_a_key,
+                &swap_token_b_key,
+                &token_b_key,
+                &mut token_b_account,
+                a_to_b_amount,
+                minimum_token_b_amount,
+            )
+        );
+
+        // swap b to a, succeeds at offset price
+        let b_to_a_amount = initial_b;
+        let minimum_token_a_amount = 0;
+        accounts
+            .swap(
+                &swapper_key,
+                &token_b_key,
+                &mut token_b_account,
+                &swap_token_b_key,
+                &swap_token_a_key,
+                &token_a_key,
+                &mut token_a_account,
+                b_to_a_amount,
+                minimum_token_a_amount,
+            )
+            .unwrap();
+
+        // try a to b again, succeeds due to new liquidity
+        accounts
+            .swap(
+                &swapper_key,
+                &token_a_key,
+                &mut token_a_account,
+                &swap_token_a_key,
+                &swap_token_b_key,
+                &token_b_key,
+                &mut token_b_account,
+                a_to_b_amount,
+                minimum_token_b_amount,
+            )
+            .unwrap();
+
+        // try a to b again, fails due to no more liquidity
+        assert_eq!(
+            Err(SwapError::ZeroTradingTokens.into()),
+            accounts.swap(
+                &swapper_key,
+                &token_a_key,
+                &mut token_a_account,
+                &swap_token_a_key,
+                &swap_token_b_key,
+                &token_b_key,
+                &mut token_b_account,
+                a_to_b_amount,
+                minimum_token_b_amount,
+            )
+        );
     }
 }


### PR DESCRIPTION
Adds the offset curve, which works very similarly to the traditional Uniswap curve, but adds in an offset amount to the token B side in order to pump up the price of token A without requiring the pool creator to put up all of the token B.  For example, if someone is doing an ICO of 1 million tokens, with the price starting at 2 USDC per token, the creator would need 2 million USDC on hand.  With the offset curve, they can even put in 0 on one side.