### PR TITLE
Program Interface implementation library for implementing programs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,7 +189,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
  "synstructure",
@@ -201,7 +201,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -265,7 +265,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -276,7 +276,7 @@ version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 2.0.15",
 ]
@@ -423,7 +423,7 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "peeking_take_while",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "regex",
  "rustc-hash",
@@ -539,7 +539,7 @@ dependencies = [
  "borsh-derive-internal",
  "borsh-schema-derive-internal",
  "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "syn 1.0.107",
 ]
 
@@ -549,7 +549,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5449c28a7b352f2d1e592a8a28bf139bc71afb0764a14f3c02500935d8c44065"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -560,7 +560,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdbd5696d8bfa21d53d9fe39a714a18538bad11492a42d066dbbc395fb1951c0"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -640,7 +640,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aca418a974d83d40a0c1f0c5cba6ff4bc28d8df099109ca459a2118d40b6322"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -699,7 +699,7 @@ dependencies = [
  "heck 0.3.3",
  "indexmap",
  "log",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "serde",
  "serde_json",
@@ -1074,7 +1074,7 @@ dependencies = [
  "cc",
  "codespan-reporting",
  "once_cell",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "scratch",
  "syn 1.0.107",
@@ -1092,7 +1092,7 @@ version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "309e4fb93eed90e1e14bea0da16b209f81813ba9fc7830c20ed151dd7bc0a4d7"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -1115,7 +1115,7 @@ checksum = "ab8bfa2e259f8ee1ce5e97824a3c55ec4404a0d772ca7fa96bf19f0752a046eb"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "strsim 0.10.0",
  "syn 2.0.15",
@@ -1195,7 +1195,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b24629208e87a2d8b396ff43b15c4afb0a69cea3fbbaa9ed9b92b7c02f0aed73"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -1207,7 +1207,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "rustc_version",
  "syn 1.0.107",
@@ -1295,7 +1295,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -1377,7 +1377,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f86b50932a01e7ec5c06160492ab660fb19b6bb2a7878030dd6cd68d21df9d4d"
 dependencies = [
  "enum-ordinalize",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -1418,7 +1418,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8958699f9359f0b04e691a13850d48b7de329138023876d07cbd024c2c820598"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -1431,7 +1431,7 @@ checksum = "0b166c9e378360dd5a6666a9604bb4f54ae0cac39023ffbac425e917a2a04fef"
 dependencies = [
  "num-bigint 0.4.3",
  "num-traits",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -1443,7 +1443,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11f36e95862220b211a6e2aa5eca09b4fa391b13cd52ceb8035a24bf65a79de2"
 dependencies = [
  "once_cell",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -1679,7 +1679,7 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 2.0.15",
 ]
@@ -2352,7 +2352,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b939a78fa820cdfcb7ee7484466746a7377760970f6f9c6fe19f9edcc8a38d2"
 dependencies = [
  "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -2746,7 +2746,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -2928,7 +2928,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -3011,7 +3011,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
 dependencies = [
  "proc-macro-crate 1.1.0",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -3023,7 +3023,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
 dependencies = [
  "proc-macro-crate 1.1.0",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 2.0.15",
 ]
@@ -3091,7 +3091,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -3168,7 +3168,7 @@ checksum = "734aa7a4a6390b162112523cac2923a18e4f23b917880a68c826bf6e8bf48f06"
 dependencies = [
  "Inflector",
  "proc-macro-error",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -3308,7 +3308,7 @@ checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
 dependencies = [
  "pest",
  "pest_meta",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -3349,7 +3349,7 @@ version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b95af56fee93df76d721d356ac1ca41fccf168bc448eb14049234df764ba3e76"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -3446,7 +3446,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b83ec2d0af5c5c556257ff52c9f98934e243b9fd39604bfb2a9b75ec2e97f18"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "syn 1.0.107",
 ]
 
@@ -3476,7 +3476,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
  "version_check",
@@ -3488,7 +3488,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "version_check",
 ]
@@ -3504,9 +3504,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
 ]
@@ -3599,7 +3599,7 @@ checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
 dependencies = [
  "anyhow",
  "itertools",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -3612,7 +3612,7 @@ checksum = "7345d5f0e08c0536d7ac7229952590239e77abf0a0100a1b1d890add6ea96364"
 dependencies = [
  "anyhow",
  "itertools",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -3730,7 +3730,7 @@ version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
 ]
 
 [[package]]
@@ -4212,7 +4212,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdbda6ac5cd1321e724fa9cee216f3a61885889b896f073b8f82322789c5250e"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -4290,7 +4290,7 @@ version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 2.0.15",
 ]
@@ -4341,7 +4341,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
 dependencies = [
  "darling",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 2.0.15",
 ]
@@ -4378,7 +4378,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 2.0.15",
 ]
@@ -4489,7 +4489,7 @@ version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd835154aa943dfc958f5a208f2e82b7d2a2c52b024229168c211ecc2d2bfd1"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "shank_macro_impl 0.0.5",
  "syn 1.0.107",
@@ -4501,7 +4501,7 @@ version = "0.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63927d22a1e8b74bda98cc6e151fcdf178b7abb0dc6c4f81e0bbf5ffe2fc4ec8"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "shank_macro_impl 0.0.11",
  "syn 1.0.107",
@@ -4514,7 +4514,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d99ad9d5137704e86e2e4a54a121b9c443c37b60ce6638a7723ab700dbd2232a"
 dependencies = [
  "anyhow",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "serde",
  "syn 1.0.107",
@@ -4527,7 +4527,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce03403df682f80f4dc1efafa87a4d0cb89b03726d0565e6364bdca5b9a441"
 dependencies = [
  "anyhow",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "serde",
  "syn 1.0.107",
@@ -5087,7 +5087,7 @@ version = "1.14.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dad43ac27c4b8d7a3ce0e2cb8642a7e3b8ea5e3c29ecea38045a8518519adccf"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "rustc_version",
  "syn 1.0.107",
@@ -5649,7 +5649,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f89a14a8f1e7708fe19ee3140125e9d8279945ead74cb09e65c94dd5cf0640c3"
 dependencies = [
  "bs58",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "rustversion",
  "syn 1.0.107",
@@ -6333,9 +6333,41 @@ dependencies = [
 name = "spl-program-error-derive"
 version = "0.1.0"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 2.0.15",
+]
+
+[[package]]
+name = "spl-program-interface"
+version = "0.1.0"
+dependencies = [
+ "solana-program",
+ "spl-program-interface-derive",
+ "spl-program-interface-syn",
+ "spl-token-metadata-interface",
+]
+
+[[package]]
+name = "spl-program-interface-derive"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2 1.0.60",
+ "quote 1.0.26",
+ "spl-program-interface-syn",
+ "syn 2.0.15",
+]
+
+[[package]]
+name = "spl-program-interface-syn"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2 1.0.60",
+ "quote 1.0.26",
+ "solana-program",
+ "spl-token-metadata-interface",
+ "syn 2.0.15",
+ "thiserror",
 ]
 
 [[package]]
@@ -6815,7 +6847,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
  "heck 0.4.0",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "rustversion",
  "syn 1.0.107",
@@ -6850,7 +6882,7 @@ version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "unicode-ident",
 ]
@@ -6861,7 +6893,7 @@ version = "2.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "unicode-ident",
 ]
@@ -6878,7 +6910,7 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
  "unicode-xid 0.2.2",
@@ -6948,7 +6980,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee42b4e559f17bce0385ebf511a7beb67d5cc33c12c96b7f4e9789919d9c10f"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -6999,7 +7031,7 @@ checksum = "d10394d5d1e27794f772b6fc854c7e91a2dc26e2cbf807ad523370c2a59c0cee"
 dependencies = [
  "cfg-if 1.0.0",
  "proc-macro-error",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -7011,7 +7043,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eeb9a44b1c6a54c1ba58b152797739dba2a83ca74e18168a68c980eb142f9404"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
  "test-case-core",
@@ -7057,7 +7089,7 @@ version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 2.0.15",
 ]
@@ -7171,7 +7203,7 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -7362,7 +7394,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9403f1bafde247186684b230dc6f38b5cd514584e8bec1dd32514be4745fa757"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "prost-build 0.9.0",
  "quote 1.0.26",
  "syn 1.0.107",
@@ -7375,7 +7407,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fbcd2800e34e743b9ae795867d5f77b535d3a3be69fd731e39145719752df8c"
 dependencies = [
  "prettyplease",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "prost-build 0.11.1",
  "quote 1.0.26",
  "syn 1.0.107",
@@ -7451,7 +7483,7 @@ version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
 ]
@@ -7784,7 +7816,7 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
  "wasm-bindgen-shared",
@@ -7818,7 +7850,7 @@ version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
  "wasm-bindgen-backend",
@@ -8168,7 +8200,7 @@ version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65f1a51723ec88c66d5d1fe80c841f17f63587d6691901d66be9bec6c3b51f73"
 dependencies = [
- "proc-macro2 1.0.56",
+ "proc-macro2 1.0.60",
  "quote 1.0.26",
  "syn 1.0.107",
  "synstructure",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
   "libraries/concurrent-merkle-tree",
   "libraries/merkle-tree-reference",
   "libraries/program-error",
+  "libraries/program-interface",
   "libraries/tlv-account-resolution",
   "libraries/type-length-value",
   "memo/program",

--- a/libraries/program-interface/Cargo.toml
+++ b/libraries/program-interface/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "spl-program-interface"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[dependencies]
+spl-program-interface-derive = { version = "0.1.0", path = "./derive" }
+spl-program-interface-syn = { version = "0.1.0", path = "./syn" }
+spl-token-metadata-interface = { version = "0.1.0", path = "../../token-metadata/interface" }
+
+[dev-dependencies]
+solana-program = "1.14.12"

--- a/libraries/program-interface/derive/Cargo.toml
+++ b/libraries/program-interface/derive/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "spl-program-interface-derive"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1.0"
+spl-program-interface-syn = { version = "0.1.0", path = "../syn" }
+syn = { version = "2.0", features = ["extra-traits"] }

--- a/libraries/program-interface/derive/src/lib.rs
+++ b/libraries/program-interface/derive/src/lib.rs
@@ -1,0 +1,17 @@
+//! Proc macro attribute for defining a Solana program interface
+//! in native or Shank programs
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use quote::ToTokens;
+use spl_program_interface_syn::InterfaceInstructionBuilder;
+use syn::parse_macro_input;
+
+/// Proc macro attribute for defining a Solana program interface
+/// in native or Shank programs
+#[proc_macro_derive(SplProgramInterface, attributes(interface))]
+pub fn spl_program_interface(input: TokenStream) -> TokenStream {
+    parse_macro_input!(input as InterfaceInstructionBuilder)
+        .to_token_stream()
+        .into()
+}

--- a/libraries/program-interface/src/lib.rs
+++ b/libraries/program-interface/src/lib.rs
@@ -1,0 +1,8 @@
+//! Crate for defining and implementing Solana program interfaces
+//! for instructions
+extern crate self as spl_program_interface;
+
+// Simply exporting both the proc_macro crate and the syn crate
+// so that everything is available downstream
+pub use spl_program_interface_derive::SplProgramInterface;
+pub use spl_program_interface_syn::*;

--- a/libraries/program-interface/syn/Cargo.toml
+++ b/libraries/program-interface/syn/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "spl-program-interface-syn"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+proc-macro2 = "1.0.59"
+quote = "1.0"
+solana-program = "1.14.12"
+spl-token-metadata-interface = { version = "0.1.0", path = "../../../token-metadata/interface" }
+syn = { version = "2.0", features = ["full"] }
+thiserror = "1.0.40"

--- a/libraries/program-interface/syn/src/error.rs
+++ b/libraries/program-interface/syn/src/error.rs
@@ -1,15 +1,70 @@
 //! Errors for the SPL interface instruction parser.
 
+use quote::quote;
+use std::collections::{HashMap, HashSet};
+
+use crate::interface::{InterfaceInstruction, RequiredArg};
+
 #[derive(Clone, Debug, Eq, thiserror::Error, PartialEq)]
 pub enum SplProgramInterfaceError {
     #[error("Error parsing interface attribute")]
     ParseError,
     #[error("Invalid interface namespace")]
     InvalidInterfaceNamespace,
-    #[error("Missing required instruction for interface")]
+    #[error("Invalid instruction namespace")]
+    InvalidInstruction,
+    #[error("Instruction not found")]
     InstructionMissing,
     #[error("Instruction not found")]
     InstructionNotFound,
     #[error("Missing argument(s) for instruction")]
     MissingArgument,
+}
+
+pub fn invalid_instruction_namespace_verbose(
+    declared_interfaces: &HashMap<String, HashSet<InterfaceInstruction>>,
+) -> SplProgramInterfaceError {
+    println!("\n\nThe following interface instructions were not implemented:\n");
+    for (namespace, set) in declared_interfaces {
+        for ix in set {
+            println!("   - {}::{}", namespace, ix.instruction_namespace);
+        }
+    }
+    println!("\n");
+    SplProgramInterfaceError::InstructionMissing
+}
+
+pub fn instruction_missing_verbose(
+    interface_namespace: &str,
+    instruction_namespace: &str,
+) -> SplProgramInterfaceError {
+    println!("\n\nFound the following unknown interface instructions:\n");
+    println!("  - {}::{}", interface_namespace, instruction_namespace);
+    println!("\n");
+    SplProgramInterfaceError::InstructionNotFound
+}
+
+pub fn missing_args_verbose(
+    interface_namespace: &str,
+    instruction_namespace: &str,
+    provided_args: &Vec<RequiredArg>,
+    required_args: &Vec<RequiredArg>,
+) -> SplProgramInterfaceError {
+    println!(
+        "\n\nIncorrect arguments for interface instruction `{}::{}`:\n",
+        interface_namespace, instruction_namespace
+    );
+    println!("Provided arguments:");
+    for arg in provided_args {
+        let ty = arg.1.clone();
+        println!("  - {}: {}", arg.0, quote! {#ty});
+    }
+    println!("\n");
+    println!("Required arguments:");
+    for arg in required_args {
+        let ty = arg.1.clone();
+        println!("  - {}: {}", arg.0, quote! {#ty});
+    }
+    println!("\n");
+    SplProgramInterfaceError::MissingArgument
 }

--- a/libraries/program-interface/syn/src/error.rs
+++ b/libraries/program-interface/syn/src/error.rs
@@ -1,0 +1,15 @@
+//! Errors for the SPL interface instruction parser.
+
+#[derive(Clone, Debug, Eq, thiserror::Error, PartialEq)]
+pub enum SplProgramInterfaceError {
+    #[error("Error parsing interface attribute")]
+    ParseError,
+    #[error("Invalid interface namespace")]
+    InvalidInterfaceNamespace,
+    #[error("Missing required instruction for interface")]
+    InstructionMissing,
+    #[error("Instruction not found")]
+    InstructionNotFound,
+    #[error("Missing argument(s) for instruction")]
+    MissingArgument,
+}

--- a/libraries/program-interface/syn/src/instructions.rs
+++ b/libraries/program-interface/syn/src/instructions.rs
@@ -4,9 +4,9 @@
 use spl_token_metadata_interface::instruction::{
     Emit, Initialize, RemoveKey, TokenMetadataInstruction, UpdateAuthority, UpdateField,
 };
-use syn::{parse_quote, ItemStruct};
+use syn::parse_quote;
 
-use crate::interface::{Interface, InterfaceInstruction, RequiredArg};
+use crate::interface::{Interface, InterfaceInstruction};
 
 pub trait AsInterfaceInstruction {
     fn as_interface_instruction() -> InterfaceInstruction;
@@ -30,7 +30,11 @@ impl AsInterfaceInstruction for Initialize {
         InterfaceInstruction {
             interface_namespace: TokenMetadataInstruction::NAMESPACE.to_string(),
             instruction_namespace: "metadata_initialize".to_string(),
-            required_args: parse_required_args(&parse_quote! { Initialize }),
+            required_args: vec![
+                ("name".to_string(), parse_quote! { String }),
+                ("symbol".to_string(), parse_quote! { String }),
+                ("uri".to_string(), parse_quote! { String }),
+            ],
         }
     }
 }
@@ -39,7 +43,10 @@ impl AsInterfaceInstruction for UpdateField {
         InterfaceInstruction {
             interface_namespace: TokenMetadataInstruction::NAMESPACE.to_string(),
             instruction_namespace: "update_field".to_string(),
-            required_args: parse_required_args(&parse_quote! { UpdateField }),
+            required_args: vec![
+                ("field".to_string(), parse_quote! { Field }),
+                ("value".to_string(), parse_quote! { String }),
+            ],
         }
     }
 }
@@ -48,7 +55,7 @@ impl AsInterfaceInstruction for RemoveKey {
         InterfaceInstruction {
             interface_namespace: TokenMetadataInstruction::NAMESPACE.to_string(),
             instruction_namespace: "remove_a_key".to_string(),
-            required_args: parse_required_args(&parse_quote! { RemoveKey }),
+            required_args: vec![("key".to_string(), parse_quote! { String })],
         }
     }
 }
@@ -57,7 +64,7 @@ impl AsInterfaceInstruction for UpdateAuthority {
         InterfaceInstruction {
             interface_namespace: TokenMetadataInstruction::NAMESPACE.to_string(),
             instruction_namespace: "update_authority".to_string(),
-            required_args: parse_required_args(&parse_quote! { UpdateAuthority }),
+            required_args: vec![("new_authority".to_string(), parse_quote! { Option<Pubkey> })],
         }
     }
 }
@@ -66,15 +73,10 @@ impl AsInterfaceInstruction for Emit {
         InterfaceInstruction {
             interface_namespace: TokenMetadataInstruction::NAMESPACE.to_string(),
             instruction_namespace: "emitting".to_string(),
-            required_args: parse_required_args(&parse_quote! { Emit }),
+            required_args: vec![
+                ("start".to_string(), parse_quote! { Option<u64> }),
+                ("end".to_string(), parse_quote! { Option<u64> }),
+            ],
         }
     }
-}
-
-fn parse_required_args(item_struct: &ItemStruct) -> Vec<RequiredArg> {
-    let mut required_args = vec![];
-    for f in &item_struct.fields {
-        required_args.push((f.ident.as_ref().unwrap().to_string(), f.ty.clone()))
-    }
-    required_args
 }

--- a/libraries/program-interface/syn/src/instructions.rs
+++ b/libraries/program-interface/syn/src/instructions.rs
@@ -1,0 +1,80 @@
+//! Implements the `Interface` traits and associated types for
+//! the interfaces contained within the Solana Program Library
+
+use spl_token_metadata_interface::instruction::{
+    Emit, Initialize, RemoveKey, TokenMetadataInstruction, UpdateAuthority, UpdateField,
+};
+use syn::{parse_quote, ItemStruct};
+
+use crate::interface::{Interface, InterfaceInstruction, RequiredArg};
+
+pub trait AsInterfaceInstruction {
+    fn as_interface_instruction() -> InterfaceInstruction;
+}
+
+impl Interface for TokenMetadataInstruction {
+    const NAMESPACE: &'static str = "spl_token_metadata_interface";
+
+    fn instructions() -> Vec<InterfaceInstruction> {
+        vec![
+            Initialize::as_interface_instruction(),
+            UpdateField::as_interface_instruction(),
+            RemoveKey::as_interface_instruction(),
+            UpdateAuthority::as_interface_instruction(),
+            Emit::as_interface_instruction(),
+        ]
+    }
+}
+impl AsInterfaceInstruction for Initialize {
+    fn as_interface_instruction() -> InterfaceInstruction {
+        InterfaceInstruction {
+            interface_namespace: TokenMetadataInstruction::NAMESPACE.to_string(),
+            instruction_namespace: "metadata_initialize".to_string(),
+            required_args: parse_required_args(&parse_quote! { Initialize }),
+        }
+    }
+}
+impl AsInterfaceInstruction for UpdateField {
+    fn as_interface_instruction() -> InterfaceInstruction {
+        InterfaceInstruction {
+            interface_namespace: TokenMetadataInstruction::NAMESPACE.to_string(),
+            instruction_namespace: "update_field".to_string(),
+            required_args: parse_required_args(&parse_quote! { UpdateField }),
+        }
+    }
+}
+impl AsInterfaceInstruction for RemoveKey {
+    fn as_interface_instruction() -> InterfaceInstruction {
+        InterfaceInstruction {
+            interface_namespace: TokenMetadataInstruction::NAMESPACE.to_string(),
+            instruction_namespace: "remove_a_key".to_string(),
+            required_args: parse_required_args(&parse_quote! { RemoveKey }),
+        }
+    }
+}
+impl AsInterfaceInstruction for UpdateAuthority {
+    fn as_interface_instruction() -> InterfaceInstruction {
+        InterfaceInstruction {
+            interface_namespace: TokenMetadataInstruction::NAMESPACE.to_string(),
+            instruction_namespace: "update_authority".to_string(),
+            required_args: parse_required_args(&parse_quote! { UpdateAuthority }),
+        }
+    }
+}
+impl AsInterfaceInstruction for Emit {
+    fn as_interface_instruction() -> InterfaceInstruction {
+        InterfaceInstruction {
+            interface_namespace: TokenMetadataInstruction::NAMESPACE.to_string(),
+            instruction_namespace: "emitting".to_string(),
+            required_args: parse_required_args(&parse_quote! { Emit }),
+        }
+    }
+}
+
+fn parse_required_args(item_struct: &ItemStruct) -> Vec<RequiredArg> {
+    let mut required_args = vec![];
+    for f in &item_struct.fields {
+        required_args.push((f.ident.as_ref().unwrap().to_string(), f.ty.clone()))
+    }
+    required_args
+}

--- a/libraries/program-interface/syn/src/interface.rs
+++ b/libraries/program-interface/syn/src/interface.rs
@@ -1,0 +1,206 @@
+//! Crate defining the `Interface` trait and related types
+//! and checks.
+//!
+//! Also provides the collection of currently accepted
+//! sRFC interfaces
+
+use quote::quote;
+use solana_program::program_error::ProgramError;
+use spl_token_metadata_interface::instruction::TokenMetadataInstruction;
+use std::collections::{HashMap, HashSet};
+use syn::{ItemFn, Type, Variant};
+
+use crate::error::SplProgramInterfaceError;
+
+/// Trait for implementing Shank & Native programs to
+/// build a processor
+///
+/// The derive macro `#[derive(SplInterfaceInstruction)]`
+/// will implement this trait for you
+pub trait InterfaceInstructionPack: Sized {
+    /// Unpacks an instruction from a buffer
+    fn unpack(buf: &[u8]) -> Result<Self, ProgramError>;
+    /// Packs an instruction into a buffer
+    fn pack<W: std::io::Write>(&self, writer: &mut W) -> Result<(), ProgramError>;
+}
+
+/// Trait defining a Solana program interface
+pub trait Interface {
+    /// The interface's namespace
+    const NAMESPACE: &'static str;
+    /// The instructions required by the interface
+    fn instructions() -> Vec<InterfaceInstruction>;
+    /// Returns the instructions required by the interface
+    /// as a set for evaluation
+    fn instruction_set() -> HashSet<InterfaceInstruction> {
+        let mut set = HashSet::new();
+        for instruction in Self::instructions() {
+            set.insert(instruction);
+        }
+        set
+    }
+}
+
+/// Trait defining a Solana program interface instruction
+#[derive(PartialEq, Eq, Hash)]
+pub struct InterfaceInstruction {
+    /// The interface's namespace
+    pub interface_namespace: String,
+    /// The instruction's namespace
+    pub instruction_namespace: String,
+    /// The instruction's required arguments
+    pub required_args: Vec<RequiredArg>,
+}
+impl InterfaceInstruction {
+    /// Returns the 8-byte discriminator for the instruction
+    pub fn discriminator(&self) -> [u8; 8] {
+        let mut disc = [0u8; 8];
+        disc.copy_from_slice(
+            &solana_program::hash::hash(
+                (self.interface_namespace.to_string() + ":" + &self.instruction_namespace)
+                    .as_bytes(),
+            )
+            .to_bytes()[..8],
+        );
+        disc
+    }
+    /// Converts an instruction namespace and `&ItemFn` to an
+    /// `InterfaceInstruction` for evaluation (Anchor)
+    pub fn from_item_fn(
+        interface_namespace: &String,
+        instruction_namespace: &String,
+        function: &ItemFn,
+    ) -> Self {
+        let mut required_args = vec![];
+        for arg in &function.sig.inputs {
+            if let syn::FnArg::Typed(pat_type) = arg {
+                if let syn::Pat::Ident(ident) = &*pat_type.pat {
+                    required_args.push((ident.ident.to_string(), *pat_type.ty.clone()));
+                }
+            }
+        }
+        Self {
+            interface_namespace: interface_namespace.to_string(),
+            instruction_namespace: instruction_namespace.to_string(),
+            required_args,
+        }
+    }
+    /// Converts an instruction namespace and `&Variant` to an
+    /// `InterfaceInstruction` for evaluation (Native, Shank)
+    pub fn from_variant(
+        interface_namespace: &String,
+        instruction_namespace: &String,
+        variant: &Variant,
+    ) -> Self {
+        let mut required_args = vec![];
+        for field in &variant.fields {
+            if let Some(ident) = &field.ident {
+                required_args.push((ident.to_string(), field.ty.clone()));
+            }
+        }
+        Self {
+            interface_namespace: interface_namespace.to_string(),
+            instruction_namespace: instruction_namespace.to_string(),
+            required_args,
+        }
+    }
+}
+
+/// A required argument for an instruction
+pub type RequiredArg = (String, Type);
+
+/// Evaluates a program's interface instructions against any declared interfaces
+pub fn evaluate_interface_instructions(
+    declared_instructions: Vec<InterfaceInstruction>,
+) -> Result<(), SplProgramInterfaceError> {
+    // Initialize a HashMap to keep track of all declared interfaces
+    let mut declared_interfaces: HashMap<String, HashSet<InterfaceInstruction>> = HashMap::new();
+    // Iterate through all declared instructions and
+    // evaluate them against the declared interfaces
+    for declared_ix in declared_instructions {
+        if declared_ix.interface_namespace == TokenMetadataInstruction::NAMESPACE {
+            process_declared_instruction::<TokenMetadataInstruction>(
+                &mut declared_interfaces,
+                declared_ix,
+            )?
+        } else {
+            return Err(SplProgramInterfaceError::InvalidInterfaceNamespace);
+        }
+    }
+    // Make sure all declared interfaces have no remaining unmatched instructions
+    for x in declared_interfaces.values() {
+        if !x.is_empty() {
+            dump_remaining_interface_instructions(declared_interfaces);
+            return Err(SplProgramInterfaceError::InstructionMissing);
+        }
+    }
+    Ok(())
+}
+
+/// Processed a declared instruction by checking to see if it exists in the `HashMap`
+/// and if it does, removing the instruction from the `HashSet`
+fn process_declared_instruction<I: Interface>(
+    declared_interfaces: &mut HashMap<String, HashSet<InterfaceInstruction>>,
+    declared_ix: InterfaceInstruction,
+) -> Result<(), SplProgramInterfaceError> {
+    match declared_interfaces.get_mut(&declared_ix.interface_namespace) {
+        Some(set) => {
+            if !set.remove(&declared_ix) {
+                return Err(SplProgramInterfaceError::InstructionNotFound);
+            }
+        }
+        None => {
+            let mut set = I::instruction_set();
+            if !set.remove(&declared_ix) {
+                match set
+                    .iter()
+                    .find(|i| &i.instruction_namespace == &declared_ix.instruction_namespace)
+                {
+                    Some(ins) => {
+                        println!(
+                            "\n\nIncorrect arguments for interface instruction `{}::{}`:\n",
+                            declared_ix.interface_namespace, declared_ix.instruction_namespace
+                        );
+                        println!("Provided arguments:");
+                        for arg in &declared_ix.required_args {
+                            let ty = arg.1.clone();
+                            println!("  - {}: {}", arg.0, quote! {#ty}.to_string());
+                        }
+                        println!("\n");
+                        println!("Required arguments:");
+                        for arg in &ins.required_args {
+                            let ty = arg.1.clone();
+                            println!("  - {}: {}", arg.0, quote! {#ty}.to_string());
+                        }
+                        println!("\n");
+                        return Err(SplProgramInterfaceError::MissingArgument);
+                    }
+                    None => {
+                        println!("\n\nFound the following unknown interface instructions:\n");
+                        println!(
+                            "  - {}::{}",
+                            declared_ix.interface_namespace, declared_ix.instruction_namespace
+                        );
+                        return Err(SplProgramInterfaceError::InstructionNotFound);
+                    }
+                }
+            }
+            declared_interfaces.insert(declared_ix.interface_namespace, set);
+        }
+    }
+    Ok(())
+}
+
+/// Dumps any remaining interface instructions in the evaluation
+/// set for error reporting
+fn dump_remaining_interface_instructions(
+    declared_interfaces: HashMap<String, HashSet<InterfaceInstruction>>,
+) {
+    println!("\n\nThe following interface instructions were not implemented:\n");
+    for (namespace, set) in declared_interfaces {
+        for ix in set {
+            println!("   - {}::{}", namespace, ix.instruction_namespace);
+        }
+    }
+    println!("\n");
+}

--- a/libraries/program-interface/syn/src/lib.rs
+++ b/libraries/program-interface/syn/src/lib.rs
@@ -1,0 +1,167 @@
+//! `syn` parsing crate for validating and implementing the
+//! necessary components for Solana program interface implementations
+
+mod error;
+mod instructions;
+mod interface;
+
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens};
+use syn::{parse::Parse, Attribute, ItemEnum, ItemFn};
+
+use crate::{
+    error::SplProgramInterfaceError,
+    interface::{evaluate_interface_instructions, InterfaceInstruction},
+};
+
+/// "Builder" struct for the macro attribute that will run
+/// the necessary checks and then generate the necessary
+/// tokens to implement the interface instruction discriminators
+/// (Native, Shank)
+#[derive(Debug)]
+pub struct InterfaceInstructionBuilder {
+    pub item_enum: ItemEnum,
+    pub pack_unpack: TokenStream,
+}
+
+impl TryFrom<ItemEnum> for InterfaceInstructionBuilder {
+    type Error = SplProgramInterfaceError;
+
+    fn try_from(item_enum: ItemEnum) -> Result<Self, Self::Error> {
+        let pack_unpack = process_enum(&item_enum)?;
+        Ok(Self {
+            item_enum,
+            pack_unpack,
+        })
+    }
+}
+
+impl Parse for InterfaceInstructionBuilder {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        ItemEnum::parse(input)?.try_into().map_err(|e| {
+            syn::Error::new(
+                input.span(),
+                format!("Failed to parse interface instructions: {}", e),
+            )
+        })
+    }
+}
+
+impl ToTokens for InterfaceInstructionBuilder {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        tokens.extend::<TokenStream>(self.into());
+    }
+}
+
+impl From<&InterfaceInstructionBuilder> for TokenStream {
+    fn from(builder: &InterfaceInstructionBuilder) -> Self {
+        let _item_enum = &builder.item_enum;
+        let pack_unpack = &builder.pack_unpack;
+        quote! {
+            #pack_unpack
+        }
+    }
+}
+
+/// Validate the interface instructions from a collection of
+/// defined functions (Anchor)
+pub fn process_functions(functions: Vec<&ItemFn>) -> Result<(), SplProgramInterfaceError> {
+    let mut declared_instructions = vec![];
+    for func in functions {
+        if let Some(interface_attr) = func
+            .attrs
+            .iter()
+            .find(|attr| attr.path().is_ident("interface"))
+        {
+            if let Ok((interface_namespace, instruction_namespace)) =
+                extract_interface_from_attribute(interface_attr)
+            {
+                declared_instructions.push(InterfaceInstruction::from_item_fn(
+                    &interface_namespace,
+                    &instruction_namespace,
+                    func,
+                ));
+            }
+        }
+    }
+    evaluate_interface_instructions(declared_instructions)
+}
+
+/// Validate the interface instructions from a defined
+/// instruction enum and implement the required
+/// traits (Native, Shank)
+fn process_enum(item_enum: &ItemEnum) -> Result<TokenStream, SplProgramInterfaceError> {
+    let mut declared_instructions = vec![];
+    for variant in &item_enum.variants {
+        if let Some(interface_attr) = variant
+            .attrs
+            .iter()
+            .find(|attr| attr.path().is_ident("interface"))
+        {
+            if let Ok((interface_namespace, instruction_namespace)) =
+                extract_interface_from_attribute(interface_attr)
+            {
+                declared_instructions.push(InterfaceInstruction::from_variant(
+                    &interface_namespace,
+                    &instruction_namespace,
+                    variant,
+                ));
+            }
+        }
+    }
+    evaluate_interface_instructions(declared_instructions).map(|_| generate_pack_unpack(item_enum))
+}
+
+/// Extracts the interface namespace and instruction namespace
+/// from an attribute annotation
+fn extract_interface_from_attribute(
+    interface_attr: &Attribute,
+) -> Result<(String, String), SplProgramInterfaceError> {
+    let mut res: (String, String) = (String::default(), String::default());
+    match interface_attr.parse_nested_meta(|meta| {
+        res = (
+            meta.path.segments[0].ident.to_string(),
+            meta.path.segments[1].ident.to_string(),
+        );
+        Ok(())
+    }) {
+        Ok(_) => Ok(res),
+        Err(e) => {
+            println!("Error parsing interface attribute: {}", e);
+            Err(SplProgramInterfaceError::ParseError)
+        }
+    }
+}
+
+/// Generate the pack and unpack implementations for the
+/// instruction enum declared by the program
+fn generate_pack_unpack(item_enum: &ItemEnum) -> TokenStream {
+    // let ident = &item_enum.ident;
+    // let (unpack_arms, pack_arms) = build_pack_unpack_arms(item_enum);
+    // quote! {
+    //     impl InterfaceInstructionPack for #ident {
+    //         fn unpack(buf: &[u8]) -> Result<Self, solana_program::program_error::ProgramError> {
+    //             let (discrim, rest) = buf.split_at(8);
+    //             if discrim.len() < 8 {
+    //                 return Err(solana_program::program_error::ProgramError::InvalidInstructionData);
+    //             }
+    //             match discrim {
+    //                 #(#unpack_arms)*
+    //                 _ => Err(solana_program::program_error::ProgramError::InvalidInstructionData)
+    //             }
+    //         }
+    //         fn pack<W: std::io::Write>(&self, writer: &mut W) -> Result<(), solana_program::program_error::ProgramError> {
+    //             match self {
+    //                 #(#pack_arms)*
+    //             }
+    //         }
+    //     }
+    // }
+    quote! {}
+}
+
+/// Build the pack and unpack arms for the generated tokens
+fn build_pack_unpack_arms(item_enum: &ItemEnum) -> (Vec<TokenStream>, Vec<TokenStream>) {
+    // TODO
+    (vec![quote! {}], vec![quote! {}])
+}

--- a/libraries/program-interface/tests/mod.rs
+++ b/libraries/program-interface/tests/mod.rs
@@ -1,0 +1,27 @@
+use solana_program::pubkey::Pubkey;
+use spl_program_interface::*;
+use spl_token_metadata_interface::instruction::Field;
+
+#[derive(SplProgramInterface)]
+pub enum SampleToken {
+    #[interface(spl_token_metadata_interface::metadata_initialize)]
+    Initialize {
+        name: String,
+        symbol: String,
+        uri: String,
+    },
+    #[interface(spl_token_metadata_interface::update_field)]
+    UpdateField { field: Field, value: String },
+    #[interface(spl_token_metadata_interface::remove_a_key)]
+    RemoveKey { key: String },
+    #[interface(spl_token_metadata_interface::update_authority)]
+    UpdateAuthority { new_authority: Option<Pubkey> },
+    #[interface(spl_token_metadata_interface::emitting)]
+    Emit {
+        start: Option<u64>,
+        end: Option<u64>,
+    },
+}
+
+#[test]
+fn test_compiles() {}


### PR DESCRIPTION
After reviewing your latest PR for the Token Metadata Interface, I decided to re-work the stuff I was laying down in [this repo I linked in your PR](https://github.com/buffalojoec/srfc-interface-discriminators) into a draft PR that would actually leverage the instructions from an interface the way you wrote them in Token Metadata @joncinque .

This is only a draft for now, but I'd like to get your thoughts @joncinque @ngundotra

---

The reason I'm sharing now - while it's still a draft - is because I'd like to discuss the formatting for interfaces declared in the SPL repository, and adding only whatever necessary traits/constants/etc. for validation. We can get a little thread going below on ideas.

Mainly to replace the manual implementations here: https://github.com/buffalojoec/solana-program-library-jonc/blob/interface-instructions/libraries/program-interface/syn/src/instructions.rs

---

I encourage you guys to take a look at the README in the linked repo, and also [this test file](https://github.com/buffalojoec/srfc-interface-discriminators/blob/main/interface-instructions/tests/mod.rs) to get an understanding of what I'm shooting for.

The macro-esque code is for Shank & Native, but the underlying functions for validation and discriminators would be leveraged by Anchor.